### PR TITLE
Implement ModifyPlan so that result is known at plan time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## Unreleased
+
+* [#3](https://github.com/persona-id/terraform-provider-stablepairer/pull/3)
+  Implement ModifyPlan so that result is known at plan time.
+  ([@drcapulet])
+
 ## 1.0.0
 
-FEATURES:
-
-- Initial release
+Initial release.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Terraform provider provides a resource that keeps a stable mapping between 
 ## Requirements
 
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.19
+- [Go](https://golang.org/doc/install) >= 1.20
 
 ## Building The Provider
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-stablepairer
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.16.0

--- a/internal/provider/resource_pair_test.go
+++ b/internal/provider/resource_pair_test.go
@@ -4,6 +4,8 @@
 package provider
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -11,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccResourcePair(t *testing.T) {
@@ -44,10 +47,34 @@ func TestAccResourcePair(t *testing.T) {
 			{
 				Config: `
 				resource "stablepairer_pair" "test" {
+					keys   = ["a", "b", "c"]
+					values = ["1", "2", "3"]
+				}
+				`,
+				PlanOnly: true,
+			},
+			{
+				Config: `
+				resource "stablepairer_pair" "test" {
 					keys   = ["a", "c"]
 					values = ["1", "2", "3"]
 				}
 				`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						ExpectResultBeforeAfter{
+							Before: map[string]string{
+								"a": "1",
+								"b": "2",
+								"c": "3",
+							},
+							After: map[string]string{
+								"a": "1",
+								"c": "3",
+							},
+						},
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.#", "2"),
 					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.0", "a"),
@@ -68,6 +95,21 @@ func TestAccResourcePair(t *testing.T) {
 					values = ["1", "2", "3"]
 				}
 				`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						ExpectResultBeforeAfter{
+							Before: map[string]string{
+								"a": "1",
+								"c": "3",
+							},
+							After: map[string]string{
+								"a": "1",
+								"c": "3",
+								"e": "2",
+							},
+						},
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.#", "3"),
 					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.0", "a"),
@@ -81,6 +123,72 @@ func TestAccResourcePair(t *testing.T) {
 					resource.TestCheckResourceAttr("stablepairer_pair.test", "result.a", "1"),
 					resource.TestCheckResourceAttr("stablepairer_pair.test", "result.c", "3"),
 					resource.TestCheckResourceAttr("stablepairer_pair.test", "result.e", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourcePairEmptyStart(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"stablepairer": providerserver.NewProtocol6WithError(New("test")()),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "stablepairer_pair" "test" {
+					keys   = ["a", "b", "c"]
+					values = []
+				}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.#", "3"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.0", "a"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.1", "b"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.2", "c"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "values.#", "0"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "result.%", "0"),
+				),
+			},
+			{
+				Config: `
+				resource "stablepairer_pair" "test" {
+					keys   = ["a", "b", "c"]
+					values = []
+				}
+				`,
+				PlanOnly: true,
+			},
+			{
+				Config: `
+				resource "stablepairer_pair" "test" {
+					keys   = ["a", "b", "c"]
+					values = ["1", "2"]
+				}
+				`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						ExpectResultBeforeAfter{
+							Before: map[string]string{},
+							After: map[string]string{
+								"a": "1",
+								"b": "2",
+							},
+						},
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.#", "3"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.0", "a"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.1", "b"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "keys.2", "c"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "values.#", "2"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "values.0", "1"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "values.1", "2"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "result.%", "2"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "result.a", "1"),
+					resource.TestCheckResourceAttr("stablepairer_pair.test", "result.b", "2"),
 				),
 			},
 		},
@@ -231,4 +339,55 @@ func TestInternalPairStable(t *testing.T) {
 			}
 		})
 	}
+}
+
+var _ plancheck.PlanCheck = ExpectResultBeforeAfter{}
+
+type ExpectResultBeforeAfter struct {
+	Before map[string]string
+	After  map[string]string
+}
+
+func (pc ExpectResultBeforeAfter) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	var result error
+
+	for _, rc := range req.Plan.ResourceChanges {
+		result = errors.Join(result, convertAndCheck("before", rc.Address, pc.Before, rc.Change.Before))
+
+		result = errors.Join(result, convertAndCheck("after", rc.Address, pc.After, rc.Change.After))
+	}
+
+	resp.Error = result
+}
+
+func convertAndCheck(name, address string, expectedValue map[string]string, valueInterface interface{}) error {
+	var err error
+
+	if value, ok := valueInterface.(map[string]interface{}); ok {
+		if result, ok := value["result"]; ok {
+			if resultCast, ok := result.(map[string]interface{}); ok {
+				resultConverted := make(map[string]string, len(resultCast))
+
+				for key, value := range resultCast {
+					if valueCast, ok := value.(string); ok {
+						resultConverted[key] = valueCast
+					} else {
+						err = errors.Join(err, fmt.Errorf("unable to cast %s result for %s at %s", name, address, key))
+					}
+				}
+
+				if !reflect.DeepEqual(expectedValue, resultConverted) {
+					err = errors.Join(err, fmt.Errorf("%s differed for %s, expected %+v but was %+v", name, address, expectedValue, resultConverted))
+				}
+			} else {
+				err = errors.Join(err, fmt.Errorf("unable to cast %s result for %s", name, address))
+			}
+		} else {
+			err = errors.Join(err, fmt.Errorf("unable to read %s result for %s", name, address))
+		}
+	} else {
+		err = errors.Join(err, fmt.Errorf("unable to read %s for %s", name, address))
+	}
+
+	return err
 }


### PR DESCRIPTION
Terraform was smart enough to not make changes to resources when the mapping didn't change at apply time but left you with a plan that indicated it would - this fixes that. Upgrade to Go 1.20 was required for `errors.Join`.

Also fixed a few errors not being passed to diagnostics. 