### PR TITLE
ci: make the automerge label functional for low-risk Renovate PRs

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -1,0 +1,41 @@
+name: Auto-approve bot dependency PRs
+
+# main requires one approving review with enforce_admins on and no bypass allowances,
+# so Renovate's platformAutomerge cannot merge anything without this approval.
+#
+# pull_request_target, not pull_request: it runs the workflow definition from the
+# base branch, so a PR cannot edit its own approval conditions. Safe here only
+# because nothing below checks out the head ref.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, labeled]
+
+permissions: {}
+
+jobs:
+  approve:
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'automerge') &&
+      (github.event.pull_request.user.login == 'renovate[bot]' ||
+       github.event.pull_request.user.login == 'dependabot[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          already=$(gh api "repos/$REPO/pulls/$PR/reviews" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
+          if [ "$already" -gt 0 ]; then
+            echo "Already approved, nothing to do."
+            exit 0
+          fi
+          gh api --method POST "repos/$REPO/pulls/$PR/reviews" \
+            -f event=APPROVE \
+            -f body="Approved automatically: low-risk dependency update carrying the automerge label."

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,23 @@
       "matchDepTypes": ["indirect"],
       "minimumReleaseAge": "7 days",
       "enabled": true
+    },
+    {
+      "description": "Low-risk: Go module minor and patch",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "7 days",
+      "addLabels": ["automerge"],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "Low-risk: GitHub Actions minor and patch",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "addLabels": ["automerge"],
+      "automerge": true,
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
Ports the Renovate automerge automation already running in persona-infra-bot and incident-notebook.

# Potential Risk

Worst Case Incident: SEV(4)

A bad dependency self-merges into main. Coverage here is four required checks (Build, Generate, and Acceptance Tests on Terraform 1.13.* and 1.14.*), against the single build job in persona-infra-bot where this pattern already ships. The residual revert-on-red exposure is tracked in [INFR-3717](https://withpersona.atlassian.net/browse/INFR-3717).

# Testing Strategy

`renovate-config-validator` passes against the new config. CI on this PR runs the same four checks that will gate the self-merges.

Closes [INFR-3734](https://withpersona.atlassian.net/browse/INFR-3734)

🤖 Generated with Claude Code


[INFR-3717]: https://withpersona.atlassian.net/browse/INFR-3717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[INFR-3734]: https://withpersona.atlassian.net/browse/INFR-3734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ